### PR TITLE
fix state inclusion

### DIFF
--- a/rest-api-sdk/src/utils/OAuthUtils.js
+++ b/rest-api-sdk/src/utils/OAuthUtils.js
@@ -68,7 +68,7 @@
               RESPONSE_TYPE + EQUALS + responseType + PARAM_SEPARATOR +
               CLIENT_ID + EQUALS + clientId + PARAM_SEPARATOR +
               SCOPE + EQUALS + scopes +
-              (!state ? (PARAM_SEPARATOR + STATE + EQUALS + state) : "");
+              (state ? (PARAM_SEPARATOR + STATE + EQUALS + state) : "");
       
     };
   return OAuthUtils;


### PR DESCRIPTION
Check for `state` in OAuth params is backwards. It is being included when falsy, and excluded when present.